### PR TITLE
Update docstrings with new tasseled cap references (#63)

### DIFF
--- a/eemont/image.py
+++ b/eemont/image.py
@@ -1410,6 +1410,9 @@ def tasseledCap(self):
     supported platforms:
 
     * Sentinel-2 MSI Level 1C [1]_
+    * Landsat 9 OLI-2 SR [2]_
+    * Landsat 9 OLI-2 TOA [2]_
+    * Landsat 8 OLI SR [2]_
     * Landsat 8 OLI TOA [2]_
     * Landsat 7 ETM+ TOA [3]_
     * Landsat 5 TM Raw DN [4]_
@@ -1434,9 +1437,10 @@ def tasseledCap(self):
         Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
         of Selected Topics in Applied Earth Observations and Remote Sensing, 1–11.
         doi:10.1109/jstars.2019.2938388
-    .. [2] Baig, M.H.A., Zhang, L., Shuai, T. and Tong, Q., 2014. Derivation of a
-        tasselled cap transformation based on Landsat 8 at-satellite reflectance.
-        Remote Sensing Letters, 5(5), pp.423-431.
+    .. [2] Zhai, Y., Roy, D.P., Martins, V.S., Zhang, H.K., Yan, L., Li, Z. 2022.
+        Conterminous United States Landsat-8 top of atmosphere and surface reflectance
+        tasseled cap transformation coefficeints. Remote Sensing of Environment, 
+        274(2022). doi:10.1016/j.rse.2022.112992
     .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
         Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
         reflectance. International journal of remote sensing, 23(8), pp.1741-1748.

--- a/eemont/imagecollection.py
+++ b/eemont/imagecollection.py
@@ -1065,6 +1065,9 @@ def tasseledCap(self):
     supported platforms:
 
     * Sentinel-2 MSI Level 1C [1]_
+    * Landsat 9 OLI-2 SR [2]_
+    * Landsat 9 OLI-2 TOA [2]_
+    * Landsat 8 OLI SR [2]_
     * Landsat 8 OLI TOA [2]_
     * Landsat 7 ETM+ TOA [3]_
     * Landsat 5 TM Raw DN [4]_
@@ -1089,9 +1092,10 @@ def tasseledCap(self):
         Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
         of Selected Topics in Applied Earth Observations and Remote Sensing, 1–11.
         doi:10.1109/jstars.2019.2938388
-    .. [2] Baig, M.H.A., Zhang, L., Shuai, T. and Tong, Q., 2014. Derivation of a
-        tasselled cap transformation based on Landsat 8 at-satellite reflectance.
-        Remote Sensing Letters, 5(5), pp.423-431.
+    .. [2] Zhai, Y., Roy, D.P., Martins, V.S., Zhang, H.K., Yan, L., Li, Z. 2022.
+        Conterminous United States Landsat-8 top of atmosphere and surface reflectance
+        tasseled cap transformation coefficeints. Remote Sensing of Environment, 
+        274(2022). doi:10.1016/j.rse.2022.112992
     .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
         Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
         reflectance. International journal of remote sensing, 23(8), pp.1741-1748.


### PR DESCRIPTION
Closes #63 by updating the `tasseledCap` docstring references to be consistent with the `ee_extra` implementation (see r-earthengine/ee_extra#43). 

:)