### PR TITLE
Remove `pkg_resources` dependency

### DIFF
--- a/eemont/common.py
+++ b/eemont/common.py
@@ -9,7 +9,6 @@ import ee_extra
 import ee_extra.Spectral.core
 import ee_extra.STAC.core
 import ee_extra.STAC.utils
-import pkg_resources
 import requests
 from box import Box
 from geopy.geocoders import get_geocoder_for_service


### PR DESCRIPTION
Importing `eemont` in python 3.12 now shows warning:
```
C:\ProgramData\miniforge3\envs\geo\Lib\site-packages\ee_extra\ImageCollection\core.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

Probably `pkg_resources` shouldn't be used anymore. Why it even was there?